### PR TITLE
Fixed the invalid Go module path of the plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/steampipe-plugin-consul
+module github.com/turbot/steampipe-plugin-consul
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/steampipe-plugin-consul/consul"
+	"github.com/turbot/steampipe-plugin-consul/consul"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
